### PR TITLE
idiomatic GraphQL + StepZen wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Consuming GraphQL example with Java, Spring Boot & Vaadin
 
-This example app shows how to consume trivial data from a GraphQL API exposed
-by StepZen.
+This example app shows how to consume trivial data from a GraphQL API.
+The GraphQL API is provided by [StepZen](https://stepzen.com), and is based on the `https://ip-api.com` IP Geolocation service.
 
 The example app looks like this:
 ![Screenshot](https://github.com/mstahv/accessing-graphql-service/raw/main/assets/screenshot.png "Screenshot")

--- a/src/main/java/org/example/IpApiService.java
+++ b/src/main/java/org/example/IpApiService.java
@@ -10,16 +10,15 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Service
 public class IpApiService {
 
-    @Value("${stepzensource}")
-    private String stepzenSourceUrl;
+    @Value("${graphqlApiUrl}")
+    private String graphqlApiUrl;
 
     GraphQlClient client;
 
     @PostConstruct
     void init() {
-        WebClient wc = WebClient.create(stepzenSourceUrl);
-        HttpGraphQlClient graphQlClient = HttpGraphQlClient.create(wc);
-        client = graphQlClient;
+        WebClient wc = WebClient.create(graphqlApiUrl);
+        client = HttpGraphQlClient.create(wc);
     }
 
     public LocationDTO findIpDetails(String ipOrDomainName) {

--- a/src/main/java/org/example/IpApiService.java
+++ b/src/main/java/org/example/IpApiService.java
@@ -24,8 +24,8 @@ public class IpApiService {
 
     public LocationDTO findIpDetails(String ipOrDomainName) {
         String document = """
-            {
-                  ipApi_location(ip: "ARG") {
+            query ipQuery($ip: String!) {
+              ipApi_location(ip: $ip) {
                 ip
                 city
                 country
@@ -35,9 +35,10 @@ public class IpApiService {
                 lon
               }
             }
-        """.replace("ARG", ipOrDomainName);
+        """;
 
         return client.document(document)
+                .variable("ip", ipOrDomainName)
                 .retrieve("ipApi_location")
                 .toEntity(LocationDTO.class)
                 .block();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-stepzensource = https://graphqla2.stepzen.net/api/a2309a71f768c83c5c6e18dfef6959c4/__graphql
+# GraphQL API powered by StepZen (see https://graphql.stepzen.com/ip-api)
+graphqlApiUrl = https://graphqla2.stepzen.net/api/a2309a71f768c83c5c6e18dfef6959c4/__graphql


### PR DESCRIPTION
- [fix: use GraphQL vars instead of inlining](https://github.com/mstahv/accessing-graphql-service/commit/db39b63dca758351d791402f2bb36128c7e38c00) 

   String replacement works for an ip address, but is not generally recommended. It would fail if the arg value has "special" characters like quotes that need to be escaped in a GraphQL query. Using request variables is the recommended way of passing arguments in GraphQL requests.
  
- [wording: StepZen adds GraphQL to an existing (REST) API](https://github.com/mstahv/accessing-graphql-service/commit/b8267a1818fcb6f6a8f87c4a3a367ba70d502848) 

   Minor wording adjustments to clarify:
   - the IP Geolocation service is provided by a third-party
   - StepZen creates a GraphQL API on top of that